### PR TITLE
Pytorch Device handling

### DIFF
--- a/pytest/batching/test_batch.py
+++ b/pytest/batching/test_batch.py
@@ -1,0 +1,57 @@
+import pytest
+import torch
+from ml_gym.batching.batch import InferenceResultBatch, DatasetBatch
+
+
+class TestInferenceResultBatch:
+    target_key = "target_key"
+    prediction_key = "prediction_key"
+
+    @pytest.fixture
+    def inference_batch_result(self) -> InferenceResultBatch:
+        targets = torch.IntTensor([0, 0, 0, 1, 1, 1])
+        tags = torch.IntTensor([0, 0, 0, 1, 1, 1])
+        predictions = torch.FloatTensor([0, 0.1, 0.01, 0.9, 0.7, 1])
+        return InferenceResultBatch(targets={TestInferenceResultBatch.target_key: targets},
+                                    predictions={TestInferenceResultBatch.prediction_key: predictions},
+                                    tags=tags)
+
+    # test device operations
+    def test_to_device(self, inference_batch_result: InferenceResultBatch):
+        inference_batch_result.to_device(torch.device("cpu"))
+
+    def test_to_cpu(self, inference_batch_result: InferenceResultBatch):
+        inference_batch_result.to_cpu()
+
+    def test_get_device(self, inference_batch_result: InferenceResultBatch):
+        inference_batch_result.to_device(torch.device("cpu"))
+        assert inference_batch_result.get_device() == torch.device("cpu")
+
+    def test_detach(self, inference_batch_result: InferenceResultBatch):
+        inference_batch_result.detach()
+
+
+class TestDatasetBatch:
+    target_key = "target_key"
+    prediction_key = "prediction_key"
+
+    @pytest.fixture
+    def dataset_batch(self) -> DatasetBatch:
+        tensor = torch.IntTensor([0, 0, 0, 1, 1, 1])
+        return DatasetBatch(targets={TestDatasetBatch.target_key: tensor.clone()},
+                            samples=tensor.clone(),
+                            tags=tensor.clone())
+
+    # test device operations
+    def test_to_device(self, dataset_batch: DatasetBatch):
+        dataset_batch.to_device(torch.device("cpu"))
+
+    def test_to_cpu(self, dataset_batch: DatasetBatch):
+        dataset_batch.to_cpu()
+
+    def test_get_device(self, dataset_batch: DatasetBatch):
+        dataset_batch.to_device(torch.device("cpu"))
+        assert dataset_batch.get_device() == torch.device("cpu")
+
+    def test_detach(self, dataset_batch: DatasetBatch):
+        dataset_batch.detach()

--- a/src/ml_gym/gym/inference_component.py
+++ b/src/ml_gym/gym/inference_component.py
@@ -6,6 +6,7 @@ from ml_gym.gym.predict_postprocessing_component import PredictPostprocessingCom
 from ml_gym.gym.post_processing import PredictPostProcessingIF
 import tqdm
 from ml_gym.data_handling.dataset_loader import DatasetLoader
+from copy import deepcopy
 
 
 class ExportedModel:
@@ -22,7 +23,7 @@ class ExportedModel:
     def predict_dataset_batch(self, batch: DatasetBatch) -> InferenceResultBatch:
         with torch.no_grad():
             forward_result = self.model.forward(batch.samples)
-        result_batch = InferenceResultBatch(targets=batch.targets, tags=batch.tags, predictions=forward_result)
+        result_batch = InferenceResultBatch(targets=deepcopy(batch.targets), tags=deepcopy(batch.tags), predictions=forward_result)
         return PredictPostprocessingComponent.post_process(result_batch, post_processors=self.post_processors)
 
     def predict_data_loader(self, dataset_loader: DatasetLoader) -> InferenceResultBatch:


### PR DESCRIPTION
* DatasetBatch and InferenceResultBatch have now device methods such as detach, to_device, get_device, to_cpu
* Reduced  GPU memory footprint in Trainer and Evaluator by moving respective batches to CPU directly after instantiation.  