### PR TITLE
Implemented GymJobLite which keeps track of the training / evaluation…

### DIFF
--- a/example/conv_net_blueprint.py
+++ b/example/conv_net_blueprint.py
@@ -3,7 +3,7 @@ import torch
 from conv_net import ConvNet
 from ml_gym.blueprints.constructables import ModelRegistryConstructable
 from ml_gym.blueprints.blue_prints import BluePrint
-from ml_gym.gym.jobs import AbstractGymJob, GymJob
+from ml_gym.gym.jobs import AbstractGymJob, GymJobFactory
 from ml_gym.batching.batch import DatasetBatch
 from dataclasses import dataclass
 from ml_gym.blueprints.component_factory import ComponentFactory, Injector
@@ -41,12 +41,13 @@ class MyModelRegistryConstructable(ModelRegistryConstructable):
 
 
 class ConvNetBluePrint(BluePrint):
-    def __init__(self, run_mode: AbstractGymJob.Mode, config: Dict, epochs: List[int], dashify_logging_dir: str, grid_search_id: str,
+    def __init__(self, run_mode: AbstractGymJob.Mode, job_type: AbstractGymJob.Type, config: Dict, epochs: List[int],
+                 dashify_logging_dir: str, grid_search_id: str,
                  run_id: str, external_injection: Dict[str, Any] = None):
         model_name = "conv_net"
         dataset_name = ""
-        super().__init__(model_name, dataset_name, epochs, config, dashify_logging_dir, grid_search_id, run_id, external_injection)
-        self.run_mode = run_mode
+        super().__init__(run_mode, job_type, model_name, dataset_name, epochs, config, dashify_logging_dir, grid_search_id,
+                         run_id, external_injection)
 
     @staticmethod
     def construct_components(config: Dict, component_names: List[str], external_injection: Dict[str, Any] = None) -> Dict[str, Any]:
@@ -68,5 +69,6 @@ class ConvNetBluePrint(BluePrint):
         component_names = ["model", "trainer", "optimizer", "evaluator"]
         components = ConvNetBluePrint.construct_components(self.config, component_names, self.external_injection)
 
-        gym_job = GymJob(self.run_mode, experiment_info=experiment_info, epochs=self.epochs, **components)
+        gym_job = GymJobFactory.get_gym_job(self.run_mode, job_type=self.job_type,
+                                            experiment_info=experiment_info, epochs=self.epochs, **components)
         return gym_job

--- a/example/run.py
+++ b/example/run.py
@@ -14,6 +14,8 @@ def parse_args():
     parser.add_argument('--evaluation_config_path', type=str, required=False, help='Path to the evaluation config')
     parser.add_argument('--gpus', type=int, nargs='+', help='Indices of GPUs to distribute the GS over', default=None)
     parser.add_argument('--log_std_to_file', default=False, action="store_true", help='Flag for forwarding std output to file')
+    parser.add_argument('--keep_interim_results', default=False, action="store_true",
+                        help='Flag if intermediate results i.e., models, optimizer etc. states are to be stored')
 
     args = parser.parse_args()
     num_epochs = args.num_epochs
@@ -25,11 +27,12 @@ def parse_args():
     text_logging_path = args.text_logging_path
     log_std_to_file = args.log_std_to_file
     evaluation_config_path = args.evaluation_config_path
-    return num_epochs, validation_mode, dashify_logging_path, text_logging_path, gs_config_path, evaluation_config_path, process_count, gpus, log_std_to_file
+    keep_interim_results = args.keep_interim_results
+    return num_epochs, validation_mode, dashify_logging_path, text_logging_path, gs_config_path, evaluation_config_path, process_count, gpus, log_std_to_file, keep_interim_results
 
 
 if __name__ == '__main__':
-    num_epochs, validation_mode, dashify_logging_path, text_logging_path, gs_config_path, evaluation_config_path, process_count, gpus, log_std_to_file = parse_args()
+    num_epochs, validation_mode, dashify_logging_path, text_logging_path, gs_config_path, evaluation_config_path, process_count, gpus, log_std_to_file, keep_interim_results = parse_args()
     starter = MLGymStarter(blue_print_class=ConvNetBluePrint,
                            validation_mode=MLGymStarter.ValidationMode[validation_mode],
                            dashify_logging_path=dashify_logging_path,
@@ -39,5 +42,6 @@ if __name__ == '__main__':
                            log_std_to_file=log_std_to_file,
                            gs_config_path=gs_config_path,
                            evaluation_config_path=evaluation_config_path,
-                           num_epochs=num_epochs)
+                           num_epochs=num_epochs,
+                           keep_interim_results=keep_interim_results)
     starter.start()

--- a/src/ml_gym/blueprints/blue_prints.py
+++ b/src/ml_gym/blueprints/blue_prints.py
@@ -9,9 +9,11 @@ class BluePrint(ABC):
     """ Abstract class that provides a blueprint for creating `AbstractGymJob`
     """
 
-    def __init__(self, model_name: str, dataset_name: str,  epochs: List[int], config: Dict[str, Any], dashify_logging_dir: str,
+    def __init__(self, run_mode: AbstractGymJob.Mode, job_type: AbstractGymJob.Type, model_name: str, dataset_name: str,  epochs: List[int], config: Dict[str, Any], dashify_logging_dir: str,
                  grid_search_id: str, run_id: str, external_injection: Dict[str, Any] = None):
 
+        self.run_mode = run_mode
+        self.job_type = job_type
         self.config = config
         self.dashify_logging_dir = dashify_logging_dir
         self.grid_search_id = grid_search_id
@@ -42,6 +44,7 @@ class BluePrint(ABC):
 
 def create_blueprint(blue_print_class: Type[BluePrint],
                      run_mode: AbstractGymJob.Mode,
+                     job_type: AbstractGymJob.Type,
                      experiment_config: Dict[str, Any],
                      experiment_id: int,
                      dashify_logging_path: str,
@@ -57,5 +60,6 @@ def create_blueprint(blue_print_class: Type[BluePrint],
                                   run_mode=run_mode,
                                   config=experiment_config,
                                   dashify_logging_dir=dashify_logging_path,
-                                  external_injection=external_injection)
+                                  external_injection=external_injection,
+                                  job_type=job_type)
     return blue_print

--- a/src/ml_gym/gym/evaluator.py
+++ b/src/ml_gym/gym/evaluator.py
@@ -10,7 +10,7 @@ from ml_gym.metrics.metrics import Metric
 from ml_gym.models.nn.net import NNModel
 from ml_gym.loss_functions.loss_functions import Loss, LossWarmupMixin
 import tqdm
-from ml_gym.util.logger import LogLevel, ConsoleLogger
+from ml_gym.util.logger import ConsoleLogger
 import numpy as np
 
 

--- a/src/ml_gym/gym/jobs.py
+++ b/src/ml_gym/gym/jobs.py
@@ -8,15 +8,19 @@ from ml_gym.gym.stateful_components import StatefulComponent
 from ml_gym.persistency.io import DashifyReader
 from ml_gym.persistency.io import DashifyWriter
 from enum import Enum
-from typing import List
+from typing import List, Dict, Any
 from torch.optim.optimizer import Optimizer
-from ml_gym.util.logger import LogLevel, ConsoleLogger
+from ml_gym.util.logger import ConsoleLogger
 
 
 class AbstractGymJob(StatefulComponent):
     class Mode(Enum):
         EVAL = "eval"
         TRAIN = "training"
+
+    class Type(Enum):
+        STANDARD = "standard"
+        LITE = "lite"
 
     def __init__(self, experiment_info: ExperimentInfo):
         super().__init__()
@@ -49,20 +53,20 @@ class AbstractGymJob(StatefulComponent):
 
 class GymJob(AbstractGymJob):
 
-    def __init__(self, mode: AbstractGymJob.Mode.TRAIN, model: NNModel, optimizer, trainer: Trainer,
+    def __init__(self, run_mode: AbstractGymJob.Mode.TRAIN, model: NNModel, optimizer, trainer: Trainer,
                  evaluator: Evaluator, experiment_info: ExperimentInfo, epochs: List[int]):
         super().__init__(experiment_info)
-        self.mode = mode
+        self.run_mode = run_mode
         self.model = model
         self.optimizer_partial = optimizer  # TODO this is a little bit ugly.
         self.epochs = epochs
         self.evaluator = evaluator
         self.trainer = trainer
-        if self.mode == AbstractGymJob.Mode.TRAIN and epochs[0] == 0:
+        if self.run_mode == AbstractGymJob.Mode.TRAIN and epochs[0] == 0:
             DashifyWriter.save_model_state(model.state_dict(), self._experiment_info, 0)
             optimizer: Optimizer = self.optimizer_partial(params=self.model.parameters())
             DashifyWriter.save_optimizer_state(optimizer.state_dict(), self._experiment_info, 0)
-        self._execution_method = self._execute_train if mode == GymJob.Mode.TRAIN else self._execute_eval
+        self._execution_method = self._execute_train if run_mode == GymJob.Mode.TRAIN else self._execute_eval
 
     def _train_step(self, device: torch.device, measurement_id: int) -> NNModel:
         self.restore_state_in_stateful_components(measurement_id - 1)
@@ -122,3 +126,67 @@ class GymJob(AbstractGymJob):
     def _execute_eval(self, device: torch.device):
         for epoch in self.epochs:
             self._evaluation_step(device, measurement_id=epoch)
+
+
+class GymJobLite(AbstractGymJob):
+
+    def __init__(self, run_mode: AbstractGymJob.Mode, model: NNModel, optimizer, trainer: Trainer,
+                 evaluator: Evaluator, experiment_info: ExperimentInfo, epochs: List[int]):
+        super().__init__(experiment_info)
+        self.run_mode = run_mode
+        self.model = model
+        self.optimizer = optimizer(params=self.model.parameters())  # TODO this is a little bit ugly.
+        self.epochs = epochs
+        self.evaluator = evaluator
+        self.trainer = trainer
+        self._execution_method = self._execute_train if run_mode == GymJob.Mode.TRAIN else self._execute_eval
+
+    def _train_step(self, device: torch.device, measurement_id: int) -> NNModel:
+        # self.restore_state_in_stateful_components(measurement_id - 1)
+        # load model and optimizer
+        # model_state = DashifyReader.load_model_state(self._experiment_info, measurement_id - 1)
+        self.model.to(device)
+        # train
+        self.model = self.trainer.train_epoch(self.model, self.optimizer, device)
+        return self.model
+
+    def _evaluation_step(self, device: torch.device, measurement_id: int):
+        self.model.to(device)
+        evaluation_result = self.evaluator.evaluate(self.model, device)
+        DashifyWriter.log_measurement_result(evaluation_result, self._experiment_info, measurement_id=measurement_id)
+
+    def execute(self, device: torch.device):
+        """ Executes the job
+
+        Args:
+            device: torch device either CPUs or a specified GPU
+        """
+        self._execution_method(device)
+
+    def _execute_train(self, device: torch.device):
+        step_epochs = self.epochs[1:]
+        if len(self.epochs) > 0 and self.epochs[0] == 0:
+            # get initial results
+            # self.logger.log(LogLevel.DEBUG, "Executing initial evaluation step")
+            self._evaluation_step(device, measurement_id=0)
+            # train and evaluate
+
+        for epoch in step_epochs:
+            # self.logger.log(LogLevel.DEBUG, "Executing training step")
+            self._train_step(device, measurement_id=epoch)
+            # self.logger.log(LogLevel.DEBUG, "Executing evaluation step")
+            self._evaluation_step(device, epoch)
+
+    def _execute_eval(self, device: torch.device):
+        for epoch in self.epochs:
+            self._evaluation_step(device, measurement_id=epoch)
+
+
+class GymJobFactory:
+    @staticmethod
+    def get_gym_job(run_mode: AbstractGymJob.Mode, experiment_info: ExperimentInfo, epochs: List[int],
+                    job_type: AbstractGymJob.Type = AbstractGymJob.Type.STANDARD, **components: Dict[str, Any]) -> AbstractGymJob:
+        if job_type == AbstractGymJob.Type.LITE:
+            return GymJobLite(run_mode=run_mode, experiment_info=experiment_info, epochs=epochs, **components)
+        else:
+            return GymJob(run_mode=run_mode, experiment_info=experiment_info, epochs=epochs, **components)

--- a/src/ml_gym/gym/trainer.py
+++ b/src/ml_gym/gym/trainer.py
@@ -8,7 +8,7 @@ from ml_gym.gym.inference_component import InferenceComponent
 from ml_gym.gym.stateful_components import StatefulComponent
 from torch.optim.optimizer import Optimizer
 import tqdm
-from ml_gym.util.logger import LogLevel, ConsoleLogger
+from ml_gym.util.logger import ConsoleLogger
 
 
 class TrainComponent(StatefulComponent):

--- a/src/ml_gym/starter.py
+++ b/src/ml_gym/starter.py
@@ -20,7 +20,7 @@ class MLGymStarter:
 
     def __init__(self, blue_print_class: Type[BluePrint], validation_mode: ValidationMode, num_epochs: int, dashify_logging_path: str,
                  gs_config_path: str, evaluation_config_path: str, text_logging_path: str, process_count: int,
-                 gpus: List[int], log_std_to_file: bool, grid_search_id: str = None) -> None:
+                 gpus: List[int], log_std_to_file: bool, grid_search_id: str = None, keep_interim_results: bool = True) -> None:
         self.blue_print_class = blue_print_class
         self.num_epochs = num_epochs
         self.validation_mode = validation_mode
@@ -32,6 +32,7 @@ class MLGymStarter:
         self.gpus = gpus
         self.gs_config_path = gs_config_path
         self.grid_search_id = grid_search_id  # only set if we want to reevaluate a grid search
+        self.keep_interim_results = keep_interim_results
 
     @staticmethod
     def _create_gym(process_count: int, device_ids, log_std_to_file: bool) -> Gym:
@@ -86,7 +87,8 @@ class MLGymStarter:
                                                    cv_config=cv_config,
                                                    grid_search_id=grid_search_id,
                                                    blue_print_type=self.blue_print_class,
-                                                   re_eval=re_eval)
+                                                   re_eval=re_eval,
+                                                   keep_interim_results=self.keep_interim_results)
 
         nested_cv.run(blue_print_type=self.blue_print_class,
                       gym=gym,
@@ -95,7 +97,8 @@ class MLGymStarter:
                       dashify_logging_path=self.dashify_logging_path)
 
     def run_grid_search(self, gym: Gym, gs_config: Dict[str, Any], grid_search_id: str, re_eval: bool = False):
-        gs_validator = ValidatorFactory.get_gs_validator(grid_search_id=grid_search_id, re_eval=re_eval)
+        gs_validator = ValidatorFactory.get_gs_validator(grid_search_id=grid_search_id, re_eval=re_eval,
+                                                         keep_interim_results=self.keep_interim_results)
         gs_validator.run(blue_print_type=self.blue_print_class,
                          gym=gym,
                          gs_config=gs_config,

--- a/src/ml_gym/validation/gs_validator.py
+++ b/src/ml_gym/validation/gs_validator.py
@@ -8,13 +8,16 @@ from ml_gym.util.grid_search import GridSearch
 
 
 class GridSearchValidator(ValidatorIF):
-    def __init__(self, grid_search_id: str, re_eval: bool = False):
+    def __init__(self, grid_search_id: str, re_eval: bool = False, keep_interim_results: bool = True):
         self.grid_search_id = grid_search_id
         self.re_eval = re_eval
+        self.keep_interim_results = keep_interim_results
 
     def run(self, blue_print_type: Type[BluePrint], gym: Gym, gs_config: Dict[str, Any],
             num_epochs: int, dashify_logging_path: str):
         run_id_to_config_dict = {run_id: config for run_id, config in enumerate(GridSearch.create_gs_from_config_dict(gs_config))}
+        job_type = AbstractGymJob.Type.STANDARD if self.keep_interim_results else AbstractGymJob.Type.LITE
+
         blueprints = []
         for config_id, experiment_config in run_id_to_config_dict.items():
             blueprint = create_blueprint(blue_print_class=blue_print_type,
@@ -23,7 +26,8 @@ class GridSearchValidator(ValidatorIF):
                                          dashify_logging_path=dashify_logging_path,
                                          num_epochs=num_epochs,
                                          grid_search_id=self.grid_search_id,
-                                         experiment_id=config_id)
+                                         experiment_id=config_id,
+                                         job_type=job_type)
             blueprints.append(blueprint)
         gym.add_blue_prints(blueprints)
         gym.run(parallel=True)

--- a/src/ml_gym/validation/nested_cross_validation.py
+++ b/src/ml_gym/validation/nested_cross_validation.py
@@ -13,7 +13,8 @@ from ml_gym.util.grid_search import GridSearch
 class NestedCV(ValidatorIF):
     def __init__(self, dataset_iterator: DatasetIteratorIF, num_outer_loop_folds: int,
                  num_inner_loop_folds: int, inner_stratification: bool, outer_stratification: bool,
-                 target_pos: int, shuffle: bool, grid_search_id: str, seed: int, re_eval: bool = False):
+                 target_pos: int, shuffle: bool, grid_search_id: str, seed: int, re_eval: bool = False,
+                 keep_interim_results: bool = True):
         self.num_outer_loop_folds = num_outer_loop_folds
         self.num_inner_loop_folds = num_inner_loop_folds
         self.inner_stratification = inner_stratification
@@ -24,6 +25,7 @@ class NestedCV(ValidatorIF):
         self.target_pos = target_pos
         self.shuffle = shuffle
         self.re_eval = re_eval
+        self.keep_interim_results = keep_interim_results
 
     def _get_fold_indices(self) -> Tuple[List[int]]:
         splitter = SplitterFactory.get_nested_cv_splitter(num_inner_loop_folds=self.num_inner_loop_folds,
@@ -114,9 +116,11 @@ class NestedCV(ValidatorIF):
         return blueprints
 
     def run(self, blue_print_type: Type[BluePrint], gym: Gym, gs_config: Dict[str, Any], num_epochs: int, dashify_logging_path: str):
+        job_type = AbstractGymJob.Type.LITE if self.keep_interim_results else AbstractGymJob.Type.STANDARD
         blueprints = self.create_blue_prints(blue_print_type=blue_print_type,
                                              gs_config=gs_config,
                                              dashify_logging_path=dashify_logging_path,
-                                             num_epochs=num_epochs)
+                                             num_epochs=num_epochs,
+                                             job_type=job_type)
         gym.add_blue_prints(blueprints)
         gym.run(parallel=True)

--- a/src/ml_gym/validation/validator_factory.py
+++ b/src/ml_gym/validation/validator_factory.py
@@ -8,14 +8,15 @@ class ValidatorFactory:
 
     @staticmethod
     def get_nested_cv(gs_config: Dict[str, Any], cv_config: Dict[str, Any], grid_search_id: str,
-                      blue_print_type: Type[BluePrint], re_eval: bool = False) -> NestedCV:
+                      blue_print_type: Type[BluePrint], re_eval: bool = False, keep_interim_results: bool = True) -> NestedCV:
         iterator_key = cv_config["NestedCV"]["iterator_key"]
         split_key = cv_config["NestedCV"]["split_key"]
         component_names = [iterator_key]
         components = blue_print_type.construct_components(config=gs_config, component_names=component_names)
         iterator = components[iterator_key][split_key]
-        return NestedCV(dataset_iterator=iterator, grid_search_id=grid_search_id, **cv_config["NestedCV"]["config"], re_eval=re_eval)
+        return NestedCV(dataset_iterator=iterator, grid_search_id=grid_search_id, **cv_config["NestedCV"]["config"], re_eval=re_eval,
+                        keep_interim_results=keep_interim_results)
 
     @staticmethod
-    def get_gs_validator(grid_search_id: str, re_eval: bool = False) -> GridSearchValidator:
-        return GridSearchValidator(grid_search_id=grid_search_id, re_eval=re_eval)
+    def get_gs_validator(grid_search_id: str, re_eval: bool = False, keep_interim_results: bool = True) -> GridSearchValidator:
+        return GridSearchValidator(grid_search_id=grid_search_id, re_eval=re_eval, keep_interim_results=keep_interim_results)


### PR DESCRIPTION
… state in-memory instead of storing the interim states results on disc

we have two gymjob versions now:
* GymJob, which is the standard job that tracks all the interim results / states
* GymJobLite, which only stores the model, optimizer state etc. of the last epoch on disc

To use the GymJob, one has to set the  --keep_interim_results flag within the command line interface. Otherwise GymJobLite is selected. 
