### PR TITLE
Refactoring of model export 

### DIFF
--- a/src/ml_gym/gym/inference_component.py
+++ b/src/ml_gym/gym/inference_component.py
@@ -6,28 +6,6 @@ from ml_gym.gym.predict_postprocessing_component import PredictPostprocessingCom
 from ml_gym.gym.post_processing import PredictPostProcessingIF
 import tqdm
 from ml_gym.data_handling.dataset_loader import DatasetLoader
-from copy import deepcopy
-
-
-class ExportedModel:
-    def __init__(self, model: NNModel):
-        self.model = model
-
-    def predict_tensor(self, sample_tensor: torch.Tensor):
-        with torch.no_grad():
-            forward_result = self.model.forward(sample_tensor)
-        result_batch = InferenceResultBatch(targets=None, tags=None, predictions=forward_result)
-        return result_batch  # PredictPostprocessingComponent.post_process(result_batch, post_processors=self.post_processors)
-
-    def predict_dataset_batch(self, batch: DatasetBatch) -> InferenceResultBatch:
-        with torch.no_grad():
-            forward_result = self.model.forward(batch.samples)
-        result_batch = InferenceResultBatch(targets=deepcopy(batch.targets), tags=deepcopy(batch.tags), predictions=forward_result)
-        return result_batch  # PredictPostprocessingComponent.post_process(result_batch, post_processors=self.post_processors)
-
-    def predict_data_loader(self, dataset_loader: DatasetLoader) -> InferenceResultBatch:
-        result_batches = [self.predict_dataset_batch(batch) for batch in tqdm.tqdm(dataset_loader, desc="Batches processed:")]
-        return InferenceResultBatch.combine(result_batches)
 
 
 class InferenceComponent:
@@ -47,7 +25,3 @@ class InferenceComponent:
     def predict_data_loader(self, model: NNModel, dataset_loader: DatasetLoader) -> InferenceResultBatch:
         result_batches = [self.predict(model, batch) for batch in tqdm.tqdm(dataset_loader, desc="Batches processed:")]
         return InferenceResultBatch.combine(result_batches)
-
-    # TODO, this is really just a temporary hack and should be done at a different place!
-    def export_model(self, model: NNModel) -> ExportedModel:
-        return ExportedModel(model)

--- a/src/ml_gym/util/util.py
+++ b/src/ml_gym/util/util.py
@@ -1,0 +1,109 @@
+from ml_gym.blueprints.blue_prints import BluePrint
+from ml_gym.models.nn.net import NNModel
+import json
+import os
+import torch
+from data_stack.dataset.iterator import DatasetIteratorIF
+from typing import Dict, List, Type
+from copy import deepcopy
+from ml_gym.data_handling.dataset_loader import DatasetLoader
+from ml_gym.gym.inference_component import InferenceComponent
+from ml_gym.util.grid_search import GridSearch
+from ml_gym.validation.validator_factory import ValidatorFactory
+from ml_gym.io.config_parser import YAMLConfigLoader
+from ml_gym.batching.batch import InferenceResultBatch, DatasetBatch
+from ml_gym.gym.predict_postprocessing_component import PredictPostprocessingComponent
+from ml_gym.gym.post_processing import PredictPostProcessingIF
+import tqdm
+
+
+class ExportedModel:
+    def __init__(self, model: NNModel, post_processors: List[PredictPostProcessingIF]):
+        self.model = model
+        self.post_processors = post_processors
+
+    def predict_tensor(self, sample_tensor: torch.Tensor):
+        with torch.no_grad():
+            forward_result = self.model.forward(sample_tensor)
+        result_batch = InferenceResultBatch(targets=None, tags=None, predictions=forward_result)
+        result_batch = PredictPostprocessingComponent.post_process(result_batch, post_processors=self.post_processors)
+        return result_batch
+
+    def predict_dataset_batch(self, batch: DatasetBatch) -> InferenceResultBatch:
+        with torch.no_grad():
+            forward_result = self.model.forward(batch.samples)
+        result_batch = InferenceResultBatch(targets=deepcopy(batch.targets), tags=deepcopy(batch.tags), predictions=forward_result)
+        result_batch = PredictPostprocessingComponent.post_process(result_batch, post_processors=self.post_processors)
+        return result_batch
+
+    def predict_data_loader(self, dataset_loader: DatasetLoader) -> InferenceResultBatch:
+        result_batches = [self.predict_dataset_batch(batch) for batch in tqdm.tqdm(dataset_loader, desc="Batches processed:")]
+        return InferenceResultBatch.combine(result_batches)
+
+    @staticmethod
+    def from_model_and_preprocessors(model: NNModel, post_processors: List[PredictPostProcessingIF]) -> "ExportedModel":
+        return ExportedModel(model, post_processors)
+
+
+class ComponentLoader:
+
+    @staticmethod
+    def get_trained_exported_model(components: List, experiment_path: str, model_id: int, split_name: str) -> ExportedModel:
+        trained_model = ComponentLoader.get_trained_model(components, experiment_path, model_id)
+        post_processors = components["eval_component"].post_processors[split_name]
+        exported_model = ExportedModel.from_model_and_preprocessors(trained_model, post_processors)
+        return exported_model
+
+    @staticmethod
+    def get_components(experiment_path: str, blueprint_type: Type[BluePrint], component_names: List[str]):
+        config_path = os.path.join(experiment_path, "config.json")
+
+        with open(config_path, "r") as fd:
+            config = json.load(fd)
+        components = blueprint_type.construct_components(config=config, component_names=component_names)
+        return components
+
+    @staticmethod
+    def get_components_from_grid_search(gs_path: str, blueprint_type: Type[BluePrint], component_names: List[str], gs_id: int = 0):
+        run_id_to_config_dict = {str(run_id): config for run_id, config in enumerate(GridSearch.create_gs_configs_from_path(gs_path))}
+        experiment_config = run_id_to_config_dict[f"{gs_id}"]
+        components = blueprint_type.construct_components(config=experiment_config, component_names=component_names)
+        return components
+
+    @staticmethod
+    def get_components_from_nested_cv(gs_path: str, cv_path: str, blueprint_type: Type[BluePrint], component_names: List[str]):
+        gs_config = YAMLConfigLoader.load(gs_path)
+        cv_config = YAMLConfigLoader.load(cv_path)
+        nested_cv = ValidatorFactory.get_nested_cv(gs_config=gs_config,
+                                                   cv_config=cv_config,
+                                                   grid_search_id="bla",
+                                                   blue_print_type=blueprint_type)
+        blue_print = nested_cv.create_blue_prints(blueprint_type, gs_config, 1, dashify_logging_path="")[0]
+        components = blueprint_type.construct_components(
+            config=blue_print.config, component_names=component_names, external_injection=blue_print.external_injection)
+        return components
+
+    @staticmethod
+    def get_trained_model(components: List, experiment_path: str, model_id: int) -> NNModel:
+        model_state_dict_path = os.path.join(experiment_path, f"checkpoints/model_{model_id}.pt")
+        model = deepcopy(components["model"])
+        # load model
+        model_state = torch.load(model_state_dict_path)
+        model.load_state_dict(model_state)
+        return model
+
+    @staticmethod
+    def get_datasets(components: List) -> Dict[str, DatasetIteratorIF]:
+        dataset_keys = list(
+            components["evaluator"].eval_component.dataset_loaders.keys())
+        datasets_dict = {
+            key: components["evaluator"].eval_component.dataset_loaders[key].dataset for key in dataset_keys}
+        return datasets_dict
+
+    @staticmethod
+    def get_dataloaders(components: List) -> Dict[str, DatasetLoader]:
+        return components["evaluator"].eval_component.dataset_loaders
+
+    @staticmethod
+    def get_inference_component(components: List) -> InferenceComponent:
+        return components["evaluator"].eval_component.inference_component


### PR DESCRIPTION
Trained models can now be loaded and used for inference in an easier way: 

```python
from ml_gym.util.util import ExportedModel, ComponentLoader
import sys
import torch
from conv_net_blueprint import ConvNetBluePrint

experiment_path = <path to experiment>
components = ComponentLoader.get_components(experiment_path, ConvNetBluePrint, ["eval_component", "model"])
exported_model = ComponentLoader.get_trained_exported_model(components, experiment_path, model_id=2, split_name="train")

sample = torch.rand(200, 1, 28, 28)*256
result_batch = exported_model.predict_tensor(sample)
```